### PR TITLE
Refactor, part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,9 @@ install:
 
 script: go vet && go test -race -v
 
+branches:
+  only:
+    - master
+
 notifications:
   email: false

--- a/consts.go
+++ b/consts.go
@@ -16,16 +16,13 @@ const (
 	pageStatusApplied
 )
 
-var (
-	// metadata defines the WAL v1.0.0 metadata
-	metadata = Metadata{
-		Header:  "WAL",
-		Version: "1.0.0",
-	}
+const (
+	metadataHeader  = "WAL"
+	metadataVersion = "1.0"
 )
 
-// Metadata contains the header and version of the data being stored.
-type Metadata struct {
+// metadata contains the header and version of the WAL.
+type metadata struct {
 	Header, Version string
 }
 

--- a/consts.go
+++ b/consts.go
@@ -1,16 +1,14 @@
 package wal
 
-const (
-	// pageSize defines the size of a single page in the wal
-	pageSize = 4096
+import "github.com/NebulousLabs/Sia/crypto"
 
-	// maxPayloadSize defines the max size a payload can have to still fit in a single page
-	maxPayloadSize = pageSize - 64
+const (
+	pageSize       = 4096
+	pageMetaSize   = 64 // 32-byte checksum + 4 uint64s
+	maxPayloadSize = pageSize - pageMetaSize
 )
 
 const (
-	// The following enumeration defines the different possible pageStatus
-	// values
 	pageStatusInvalid = iota
 	pageStatusOther
 	pageStatusWritten
@@ -30,3 +28,5 @@ var (
 type Metadata struct {
 	Header, Version string
 }
+
+type checksum [crypto.HashSize]byte

--- a/sync.go
+++ b/sync.go
@@ -4,8 +4,8 @@ import (
 	"github.com/NebulousLabs/Sia/build"
 )
 
-// threadedWALSync syncs the wal in regular intervalls
-func threadedWALSync(w *WAL) {
+// threadedSync syncs the WAL in regular intervals
+func (w *WAL) threadedSync() {
 	for {
 		// Holding the lock of the condition is not required before calling
 		// Signal or Broadcast, but we also want to check the syncCount to
@@ -43,7 +43,7 @@ func (w *WAL) fSync() {
 	// If there is currently no instance of the syncing thread create one
 	if !w.syncing {
 		w.syncing = true
-		go threadedWALSync(w)
+		go w.threadedSync()
 	}
 
 	// Signal the syncing thread that we require syncing the wal

--- a/writeaheadlog_test.go
+++ b/writeaheadlog_test.go
@@ -439,7 +439,7 @@ func TestWalParallel(t *testing.T) {
 	}
 
 	// The number of available pages should equal the number of created pages
-	if wt.wal.filePageCount != uint64(len(wt.wal.availablePages)) {
+	if wt.wal.filePageCount != len(wt.wal.availablePages) {
 		t.Errorf("number of available pages doesn't match the number of created ones. Expected %v, but was %v",
 			wt.wal.availablePages, wt.wal.filePageCount)
 	}
@@ -512,7 +512,7 @@ func TestPageRecycling(t *testing.T) {
 		t.Errorf("The number of used pages should be greater than 0")
 	}
 	// Make sure usedPages equals availablePages and remember the values
-	if usedPages != uint64(availablePages) {
+	if usedPages != availablePages {
 		t.Errorf("number of used pages doesn't match number of available pages")
 	}
 


### PR DESCRIPTION
Probably best to step through the commit separately. 50c5ab3 is the most interesting, the rest are comparatively minor. Basically, I refactored the page marshalling to work more like Sia marshalling. I also updated the benchmark to more accurately reflect its performance. The old page marshalling allocated about 5kb; the new marshalling allocates 32 bytes.
I also added a `checksum` type for clarity.

Future work:
- I'd like to change `page.offset` to `page.index`. `page.offset` is just `page.index * pageSize`, and using an index allows you to do things like read all the pages into a slice (on startup) and index the slice directly.
- I'd like to refactor the way we save/load pages to/from disk. The tricky part of this is converting between `nextPage` pointers and integer offsets. I think I can refactor the current code to be cleaner/simpler/more efficient.
- I still need to spellcheck everything.