### PR TITLE
remove crypto import

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -1,11 +1,11 @@
 package wal
 
-import "github.com/NebulousLabs/Sia/crypto"
-
 const (
 	pageSize       = 4096
 	pageMetaSize   = 64 // 32-byte checksum + 4 uint64s
 	maxPayloadSize = pageSize - pageMetaSize
+
+	checksumSize = 32
 )
 
 const (
@@ -26,4 +26,5 @@ type metadata struct {
 	Header, Version string
 }
 
-type checksum [crypto.HashSize]byte
+// A checksum is a 256-bit blake2b hash.
+type checksum [checksumSize]byte

--- a/page_test.go
+++ b/page_test.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/fastrand"
 )
 
@@ -20,7 +19,7 @@ func TestPageMarshalling(t *testing.T) {
 		transactionNumber:   42,
 		payload:             []byte{1, 1, 2, 3, 5, 8, 13, 21, 1, 1, 2, 3, 5, 8, 13, 21},
 		pageStatus:          pageStatusComitted,
-		transactionChecksum: [crypto.HashSize]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
+		transactionChecksum: checksum{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32},
 	}
 
 	// Marshal and unmarshal data

--- a/transaction.go
+++ b/transaction.go
@@ -7,8 +7,8 @@ import (
 	"sync/atomic"
 
 	"github.com/NebulousLabs/Sia/build"
-	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/errors"
+	"golang.org/x/crypto/blake2b"
 )
 
 // Update defines a single update that can be sent to the WAL and saved
@@ -91,7 +91,7 @@ type Transaction struct {
 // checksum calculates the checksum of a transaction excluding the checksum
 // field of each page
 func (t Transaction) checksum() (c checksum) {
-	h := crypto.NewHash()
+	h, _ := blake2b.New256(nil)
 	for page := t.firstPage; page != nil; page = page.nextPage {
 		// no error possible when writing to h
 		page.writeToNoChecksum(h)

--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 
 	"github.com/NebulousLabs/Sia/build"
-	"github.com/NebulousLabs/Sia/crypto"
 	"github.com/NebulousLabs/errors"
 )
 
@@ -241,7 +240,7 @@ func (w *WAL) RecoveryComplete() error {
 	}
 
 	// Set all pages to applied.
-	for offset := int64(crypto.HashSize) + pageSize; offset < length; offset += pageSize {
+	for offset := int64(pageSize + checksumSize); offset < length; offset += pageSize {
 		if _, err := w.logFile.WriteAt(pageAppliedBytes, offset); err != nil {
 			return err
 		}


### PR DESCRIPTION
I think we could remove `build` and `errors` as well if we just defined a `extendErr` function. "A little copying is better than a little dependency." Although, part of the utility of `extendErr` functions is that you can recover the original error. So one reason to keep `errors` would be to allow users of `writeaheadlog` to recover underlying errors. But if that's the motivation, I'd argue for using [the most widely-used errors package](https://github.com/pkg/errors) :P