### PR TITLE
 replace writeTo with appendTo

### DIFF
--- a/page.go
+++ b/page.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/errors"
 )
 
@@ -93,12 +92,4 @@ func (p *page) appendTo(buf []byte) []byte {
 	copy(buf[n+32:], p.payload)
 
 	return buf
-}
-
-// WriteToFile writes the page to disk
-func (p page) writeToFile(f file) error {
-	if _, err := f.WriteAt(p.appendTo(nil), int64(p.offset)); err != nil {
-		return build.ExtendErr("Writing the page to disk failed", err)
-	}
-	return nil
 }

--- a/page.go
+++ b/page.go
@@ -77,19 +77,21 @@ func (p *page) appendTo(buf []byte) []byte {
 		nextPagePosition = math.MaxUint64
 	}
 
-	// ensure buf is large enough to hold p
-	if cap(buf) < p.size() {
-		buf = make([]byte, 0, p.size())
+	// if buf has enough capacity to hold p, use it; otherwise allocate
+	var b []byte
+	if rest := buf[len(buf):]; cap(rest) >= p.size() {
+		b = rest[:p.size()]
+	} else {
+		b = make([]byte, p.size())
 	}
-	buf = buf[:p.size()]
 
 	// write page contents
-	n := copy(buf[:], p.transactionChecksum[:])
-	binary.LittleEndian.PutUint64(buf[n:], p.pageStatus)
-	binary.LittleEndian.PutUint64(buf[n+8:], p.transactionNumber)
-	binary.LittleEndian.PutUint64(buf[n+16:], nextPagePosition)
-	binary.LittleEndian.PutUint64(buf[n+24:], uint64(len(p.payload)))
-	copy(buf[n+32:], p.payload)
+	n := copy(b, p.transactionChecksum[:])
+	binary.LittleEndian.PutUint64(b[n:], p.pageStatus)
+	binary.LittleEndian.PutUint64(b[n+8:], p.transactionNumber)
+	binary.LittleEndian.PutUint64(b[n+16:], nextPagePosition)
+	binary.LittleEndian.PutUint64(b[n+24:], uint64(len(p.payload)))
+	copy(b[n+32:], p.payload)
 
-	return buf
+	return append(buf, b...)
 }

--- a/transaction.go
+++ b/transaction.go
@@ -129,9 +129,7 @@ func (t *Transaction) commit(done chan error) {
 		done <- errors.New("Write failed on purpose")
 		return
 	}
-
-	err = t.firstPage.writeToFile(t.wal.logFile)
-	if err != nil {
+	if _, err := t.wal.logFile.WriteAt(t.firstPage.appendTo(nil), int64(t.firstPage.offset)); err != nil {
 		done <- build.ExtendErr("Writing the first page failed", err)
 		return
 	}
@@ -269,7 +267,7 @@ func (t *Transaction) SignalUpdatesApplied() error {
 		// Disk failure causes the commit to fail
 		err = errors.New("Write failed on purpose")
 	} else {
-		err = t.firstPage.writeToFile(t.wal.logFile)
+		_, err = t.wal.logFile.WriteAt(t.firstPage.appendTo(nil), int64(t.firstPage.offset))
 	}
 	if err != nil {
 		return build.ExtendErr("Couldn't write the page to file", err)

--- a/writeaheadlog_test.go
+++ b/writeaheadlog_test.go
@@ -299,7 +299,8 @@ func TestPayloadCorrupted(t *testing.T) {
 
 	// Corrupt the payload of the first txn
 	txn.firstPage.payload = fastrand.Bytes(2000)
-	if err := txn.firstPage.writeToFile(wt.wal.logFile); err != nil {
+	_, err = txn.wal.logFile.WriteAt(txn.firstPage.appendTo(nil), int64(txn.firstPage.offset))
+	if err != nil {
 		t.Errorf("Corrupting the page failed %v", err)
 	}
 
@@ -363,7 +364,8 @@ func TestPayloadCorrupted2(t *testing.T) {
 
 	// Corrupt the payload of the second txn
 	txn2.firstPage.payload = fastrand.Bytes(2000)
-	if err := txn2.firstPage.writeToFile(wt.wal.logFile); err != nil {
+	_, err = txn2.wal.logFile.WriteAt(txn2.firstPage.appendTo(nil), int64(txn2.firstPage.offset))
+	if err != nil {
 		t.Errorf("Corrupting the page failed %v", err)
 	}
 

--- a/writeaheadlog_test.go
+++ b/writeaheadlog_test.go
@@ -195,7 +195,7 @@ func TestReleaseFailed(t *testing.T) {
 
 	if len(updates2) != 1 {
 		t.Errorf("Number of updates after restart didn't match. Expected %v, but was %v",
-			0, len(updates2))
+			1, len(updates2))
 	}
 }
 


### PR DESCRIPTION
This allows us to marshal with zero allocations (amortized). It also simplifies the checksum/no checksum code: if you don't want the checksum, just drop the first 32 bytes.

I'm less certain about the second commit (removing `page.writeToFile`). It's a convenient function, but the fact that it writes at `p.offset` isn't obvious from the name, and it seems like future refactors may make `writeToFile` irrelevant anyway.