### PR TITLE
Bespoke metadata

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -23,8 +23,13 @@ const (
 )
 
 const (
-	metadataHeader  = "WAL"
-	metadataVersion = "1.0"
+	metadataHeader  = "github.com/NebulousLabs/writeaheadlog\n"
+	metadataVersion = "v1.0.0  \n" // Extra room to allow for versions like v3.14.15
+
+	// 48 bytes total, intentionally divisible by 16.
+	metadataHeaderSize = 38
+	metadataVersionSize = 9
+	metadataStatusSize = 1
 )
 
 // A checksum is a 128-bit blake2b hash.

--- a/consts.go
+++ b/consts.go
@@ -24,12 +24,12 @@ const (
 
 const (
 	metadataHeader  = "github.com/NebulousLabs/writeaheadlog\n"
-	metadataVersion = "v1.0.0  \n" // Extra room to allow for versions like v3.14.15
+	metadataVersion = "v1.0.0 \n" // Extra room to allow for versions like v3.1.41
 
 	// 48 bytes total, intentionally divisible by 16.
 	metadataHeaderSize  = 38
-	metadataVersionSize = 9
-	metadataStatusSize  = 1
+	metadataVersionSize = 8
+	metadataStatusSize  = 2
 )
 
 // A checksum is a 128-bit blake2b hash.

--- a/consts.go
+++ b/consts.go
@@ -22,14 +22,17 @@ const (
 	recoveryStateWipe
 )
 
-const (
-	metadataHeader  = "github.com/NebulousLabs/writeaheadlog\n"
-	metadataVersion = "v1.0.0 \n" // Extra room to allow for versions like v3.1.41
+var (
+	// "github.com/NebulousLabs/writeaheadlog\n"
+	metadataHeader = [38]byte{'g', 'i', 't', 'h', 'u', 'b', '.', 'c', 'o', 'm', '/',
+		'N', 'e', 'b', 'u', 'l', 'o', 'u', 's', 'L', 'a', 'b', 's', '/',
+		'w', 'r', 'i', 't', 'e', 'a', 'h', 'e', 'a', 'd', 'l', 'o', 'g', '\n'}
 
-	// 48 bytes total, intentionally divisible by 16.
-	metadataHeaderSize  = 38
-	metadataVersionSize = 8
-	metadataStatusSize  = 2
+	// "v1.0.0   \n" - 3 spaces left to leave room for vXX.XX.XX\n
+	metadataVersion = [10]byte{'v', '1', '.', '0', '.', '0', ' ', ' ', ' ', '\n'}
+
+	// First byte is the actual value, second byte is the newline.
+	metadataStatusSize = 2
 )
 
 // A checksum is a 128-bit blake2b hash.

--- a/consts.go
+++ b/consts.go
@@ -27,9 +27,9 @@ const (
 	metadataVersion = "v1.0.0  \n" // Extra room to allow for versions like v3.14.15
 
 	// 48 bytes total, intentionally divisible by 16.
-	metadataHeaderSize = 38
+	metadataHeaderSize  = 38
 	metadataVersionSize = 9
-	metadataStatusSize = 1
+	metadataStatusSize  = 1
 )
 
 // A checksum is a 128-bit blake2b hash.

--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -114,7 +114,7 @@ func (w *WAL) allocatePages(numPages int) {
 // newWal initializes and returns a wal.
 func newWal(path string, deps dependencies) (u []Update, w *WAL, err error) {
 	// Create a new WAL
-	newWal := WAL{
+	newWal := &WAL{
 		deps:     deps,
 		stopChan: make(chan struct{}),
 		path:     path,
@@ -133,7 +133,6 @@ func newWal(path string, deps dependencies) (u []Update, w *WAL, err error) {
 
 		// Recover WAL and return updates
 		updates, err := newWal.recoverWal(data)
-
 		return updates, &newWal, err
 
 	} else if !os.IsNotExist(err) {
@@ -146,15 +145,13 @@ func newWal(path string, deps dependencies) (u []Update, w *WAL, err error) {
 	if err != nil {
 		return nil, nil, build.ExtendErr("walFile could not be created", err)
 	}
-
 	// Write the metadata to the WAL
 	if err = writeWALMetadata(newWal.logFile); err != nil {
 		return nil, nil, build.ExtendErr("Failed to write metadata to file", err)
 	}
-
-	// When we create a new wal we don't need the caller to signal recoveryComplete
+	// No recovery needs to be performed.
 	newWal.recoveryComplete = true
-	return nil, &newWal, nil
+	return nil, newWal, nil
 }
 
 // readWALMetadata reads WAL metadata from the input file, returning an error

--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -467,6 +467,7 @@ func writeWALMetadata(f file) error {
 	data = append(data, []byte(metadataHeader)...)
 	data = append(data, []byte(metadataVersion)...)
 	data = append(data, byte(recoveryStateUnclean))
+	data = append(data, byte('\n'))
 	_, err := f.WriteAt(data, 0)
 	return err
 }

--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -158,7 +158,7 @@ func newWal(path string, deps dependencies) (u []Update, w *WAL, err error) {
 // if the result is unexpected.
 func readWALMetadata(data []byte) (uint16, error) {
 	// The metadata should at least long enough to contain all the fields.
-	if len(data) < metadataHeaderSize + metadataVersionSize + metadataStatusSize {
+	if len(data) < metadataHeaderSize+metadataVersionSize+metadataStatusSize {
 		return 0, errors.New("unable to read wal metadata")
 	}
 

--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -133,7 +133,7 @@ func newWal(path string, deps dependencies) (u []Update, w *WAL, err error) {
 
 		// Recover WAL and return updates
 		updates, err := newWal.recoverWal(data)
-		return updates, &newWal, err
+		return updates, newWal, err
 
 	} else if !os.IsNotExist(err) {
 		// the file exists but couldn't be opened
@@ -157,61 +157,20 @@ func newWal(path string, deps dependencies) (u []Update, w *WAL, err error) {
 // readWALMetadata reads WAL metadata from the input file, returning an error
 // if the result is unexpected.
 func readWALMetadata(data []byte) (uint16, error) {
-	buffer := bytes.NewBuffer(data)
-
-	// Data should at least be long enough to contain the recoveryState,
-	// headerLength and versionLength
-	if buffer.Len() < 6 {
-		return 0, errors.New("data is too small")
+	// The metadata should at least long enough to contain all the fields.
+	if len(data) < metadataHeaderSize + metadataVersionSize + metadataStatusSize {
+		return 0, errors.New("unable to read wal metadata")
 	}
 
-	// Prepare the variables that store the unmarshalled data
-	var recoveryState uint16
-	var headerLength uint16
-	var versionLength uint16
-
-	// Unmarshal recoveryState
-	if err := binary.Read(buffer, binary.LittleEndian, &recoveryState); err != nil {
-		return 0, build.ExtendErr("failed to unmarshal recovery state", err)
+	// Check that the header and version match.
+	if string(data[:metadataHeaderSize]) != metadataHeader {
+		return 0, errors.New("file header is incorrect")
 	}
-
-	// Unmarshal header
-	if err := binary.Read(buffer, binary.LittleEndian, &headerLength); err != nil {
-		return 0, build.ExtendErr("failed to unmarshal headerLength", err)
+	if string(data[metadataHeaderSize:metadataHeaderSize+metadataVersionSize]) != metadataVersion {
+		return 0, errors.New("file version is unrecognized - maybe you need to upgrade")
 	}
-	if uint16(buffer.Len()) < 6+headerLength {
-		return 0, errors.New("buffer is too small to contain headerData")
-	}
-	headerData := make([]byte, headerLength)
-	if _, err := buffer.Read(headerData); err != nil {
-		return 0, build.ExtendErr("failed to read headerData", err)
-	}
-
-	// Unmarshal version
-	if err := binary.Read(buffer, binary.LittleEndian, &versionLength); err != nil {
-		return 0, build.ExtendErr("failed to unmarshal headerLength", err)
-	}
-	if uint16(buffer.Len()) < 6+headerLength+versionLength {
-		return 0, errors.New("buffer is too small to contain versionData")
-	}
-	versionData := make([]byte, versionLength)
-	if _, err := buffer.Read(versionData); err != nil {
-		return 0, build.ExtendErr("failed to read versionData", err)
-	}
-
-	// Check the fields
-	if recoveryState != recoveryStateUnclean && recoveryState != recoveryStateWipe &&
-		recoveryState != recoveryStateClean {
-		return 0, errors.New("recoveryState didn't match")
-	}
-	if string(headerData) != metadataHeader {
-		return 0, errors.New("header didn't match")
-	}
-	if string(versionData) != metadataVersion {
-		return 0, errors.New("version didn't match")
-	}
-
-	return recoveryState, nil
+	// Determine and return the current status of the file.
+	return uint16(data[metadataHeaderSize+metadataVersionSize]), nil
 }
 
 // recover recovers a WAL and returns comitted but not finished updates
@@ -296,13 +255,10 @@ func (w *WAL) recoverWal(data []byte) ([]Update, error) {
 
 // writeRecoveryState is a helper function that changes the recoveryState on disk
 func (w *WAL) writeRecoveryState(state uint16) error {
-	// Set the metadata to unclean again
-	recoveryState := make([]byte, 2)
-	binary.LittleEndian.PutUint16(recoveryState, state)
-	if _, err := w.logFile.WriteAt(recoveryState, 0); err != nil {
+	_, err := w.logFile.WriteAt([]byte{byte(state)}, metadataHeaderSize+metadataVersionSize)
+	if err != nil {
 		return err
 	}
-	// Sync the new recovery state to disk
 	return w.logFile.Sync()
 }
 
@@ -506,45 +462,13 @@ func (w *WAL) wipeWAL() error {
 
 // writeWALMetadata writes WAL metadata to the input file.
 func writeWALMetadata(f file) error {
-	buffer := new(bytes.Buffer)
-
-	// Prepare the data that is written to the buffer
-	recoveryState := uint16(recoveryStateUnclean)
-	headerData := []byte(metadataHeader)
-	headerLength := uint16(len(headerData))
-	versionData := []byte(metadataVersion)
-	versionlength := uint16(len(versionData))
-
-	// Write wipe state
-	if err := binary.Write(buffer, binary.LittleEndian, &recoveryState); err != nil {
-		return build.ExtendErr("could not marshal recovery state", err)
-	}
-	// Write header length
-	if err := binary.Write(buffer, binary.LittleEndian, &headerLength); err != nil {
-		return build.ExtendErr("could not marshal header length", err)
-	}
-	// Write header
-	if _, err := buffer.Write(headerData); err != nil {
-		return build.ExtendErr("could not write header", err)
-	}
-	// Write version length
-	if err := binary.Write(buffer, binary.LittleEndian, &versionlength); err != nil {
-		return build.ExtendErr("could not marshal version length", err)
-	}
-	// Write version
-	if _, err := buffer.Write(versionData); err != nil {
-		return build.ExtendErr("could not write version data", err)
-	}
-	// Sanity check. Metadata must not be greater than pageSize
-	if buffer.Len() > pageSize {
-		panic("WAL metadata is greater than pageSize")
-	}
-	// Write marshalled data to disk
-	_, err := f.WriteAt(buffer.Bytes(), 0)
-	if err != nil {
-		return build.ExtendErr("unable to write WAL metadata", err)
-	}
-	return nil
+	// Create the metadata.
+	data := make([]byte, 0, metadataHeaderSize+metadataVersionSize+metadataStatusSize)
+	data = append(data, []byte(metadataHeader)...)
+	data = append(data, []byte(metadataVersion)...)
+	data = append(data, byte(recoveryStateUnclean))
+	_, err := f.WriteAt(data, 0)
+	return err
 }
 
 // Close closes the wal, frees used resources and checks for active

--- a/writeaheadlog_integration_test.go
+++ b/writeaheadlog_integration_test.go
@@ -416,7 +416,7 @@ func TestWALIntegration(t *testing.T) {
 		}
 
 		expectedCountdownLen := 1
-		if r & (1 << 0) == 0 {
+		if r&(1<<0) == 0 {
 			for i := 0; i < 300; i++ {
 				cd, err := newCountdown(dir)
 				if err != nil {
@@ -439,7 +439,7 @@ func TestWALIntegration(t *testing.T) {
 
 		// Continue increasing the count, but this time start performing multiple
 		// transactions between each opening and closing.
-		if r & (1 << 1) == 0 {
+		if r&(1<<1) == 0 {
 			for i := 0; i < 10; i++ {
 				cd, err := newCountdown(dir)
 				if err != nil {
@@ -466,7 +466,7 @@ func TestWALIntegration(t *testing.T) {
 		// Test the durability of the WAL. We'll initialize to simulate a disk
 		// failure after the WAL commits, but before we are able to apply the
 		// commit.
-		if r & (1 << 2) == 0 {
+		if r&(1<<2) == 0 {
 			for i := 0; i < 25; i++ {
 				cd, err := newCountdown(dir)
 				if err != nil {
@@ -518,7 +518,7 @@ func TestWALIntegration(t *testing.T) {
 		// 3 independent sets of these things, so they all have clear dependence
 		// within but no dependence next to. Then we'll update all of them and the
 		// count as well in parallel transactions.
-		if r & (1 << 3) == 0 {
+		if r&(1<<3) == 0 {
 			cd, err := newCountdown(dir)
 			if err != nil {
 				t.Fatal(err)

--- a/writeaheadlog_integration_test.go
+++ b/writeaheadlog_integration_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/NebulousLabs/Sia/build"
 	"github.com/NebulousLabs/errors"
-	"github.com/NebulousLabs/fastrand"
 )
 
 const (
@@ -397,15 +396,8 @@ func newCountdown(dir string) (*countdownArray, error) {
 // TestWALIntegration creates a plausable use case for the WAL and then
 // attempts to utilize all functions of the WAL.
 func TestWALIntegration(t *testing.T) {
-	t.Skip("Test needs to be fixed")
 	if testing.Short() {
 		t.SkipNow()
-	}
-	// Create a folder to house everything we are working with.
-	dir := build.TempDir("wal", t.Name())
-	err := os.MkdirAll(dir, 0700)
-	if err != nil {
-		t.Fatal(err)
 	}
 
 	// Create the countdown and extend the count out to 250, closing and
@@ -415,141 +407,150 @@ func TestWALIntegration(t *testing.T) {
 	//
 	// 'newCountdown' will chcek that the file is consistent, and detect that
 	// updates are being applied correctly.
-	expectedCountdownLen := 1
-	if fastrand.Intn(2) != 0 {
-		for i := 0; i < 300; i++ {
-			cd, err := newCountdown(dir)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(cd.countdown) != expectedCountdownLen {
-				t.Fatal("coundown is incorrect", len(cd.countdown), expectedCountdownLen)
-			}
-			err = cd.addCount()
-			if err != nil {
-				t.Fatal(err)
-			}
-			expectedCountdownLen++
-			err = cd.Close()
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-	}
-
-	// Continue increasing the count, but this time start performing multiple
-	// transactions between each opening and closing.
-	if fastrand.Intn(2) != 0 {
-		for i := 0; i < 10; i++ {
-			cd, err := newCountdown(dir)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			if len(cd.countdown) != expectedCountdownLen {
-				t.Fatal("coundown is incorrect", len(cd.countdown), expectedCountdownLen)
-			}
-			for j := 0; j < i; j++ {
-				err = cd.addCount()
-				if err != nil {
-					t.Fatal(err)
-				}
-				expectedCountdownLen++
-			}
-			err = cd.Close()
-			if err != nil {
-				t.Fatal(err)
-			}
-		}
-	}
-
-	// Test the durability of the WAL. We'll initialize to simulate a disk
-	// failure after the WAL commits, but before we are able to apply the
-	// commit.
-	if fastrand.Intn(2) != 0 {
-		for i := 0; i < 25; i++ {
-			cd, err := newCountdown(dir)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if len(cd.countdown) != expectedCountdownLen {
-				t.Fatal("coundown is incorrect", len(cd.countdown), expectedCountdownLen)
-			}
-
-			// Add some legitimate counts.
-			for j := 0; j < i; j++ {
-				err = cd.addCount()
-				if err != nil {
-					t.Fatal(err)
-				}
-				expectedCountdownLen++
-			}
-
-			// Add a broken count. Because the break is after the WAL commits, the
-			// count should still restore correctly on the next iteration where we
-			// call 'newCountdown'.
-			err = cd.addCountBroken()
-			if err != nil {
-				t.Fatal(err)
-			}
-			expectedCountdownLen++
-			err = cd.Close()
-			if err == nil {
-				t.Fatal("Should have returned an error but didn't")
-			}
-		}
-
-		// Check at this point that the wal is less than 100 pages.
-		info, err := os.Stat(filepath.Join(dir, "wal.dat"))
+	for r := 0; r < 16; r++ {
+		// Create a folder to house everything we are working with.
+		dir := build.TempDir("wal", t.Name())
+		err := os.MkdirAll(dir, 0700)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if info.Size() > 100*pageSize {
-			t.Error("the wal is too large")
-		}
-	}
 
-	// Test the parallelism. Basic way to do that is to have a second file that
-	// we update in parallel transactions. But I'd also like to be able to test
-	// parallel transactions that act on the same file? Not sure if that's
-	// strictly necessary. But we could have a second file that perhaps tracks
-	// two unrelated fields, like 5 integer arrays that are all intialized with
-	// the same integers, over 10kb or something. And then that file could have
-	// 3 independent sets of these things, so they all have clear dependence
-	// within but no dependence next to. Then we'll update all of them and the
-	// count as well in parallel transactions.
-	if fastrand.Intn(2) != 0 {
+		expectedCountdownLen := 1
+		if r & (1 << 0) == 0 {
+			for i := 0; i < 300; i++ {
+				cd, err := newCountdown(dir)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(cd.countdown) != expectedCountdownLen {
+					t.Fatal("coundown is incorrect", len(cd.countdown), expectedCountdownLen)
+				}
+				err = cd.addCount()
+				if err != nil {
+					t.Fatal(err)
+				}
+				expectedCountdownLen++
+				err = cd.Close()
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+
+		// Continue increasing the count, but this time start performing multiple
+		// transactions between each opening and closing.
+		if r & (1 << 1) == 0 {
+			for i := 0; i < 10; i++ {
+				cd, err := newCountdown(dir)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if len(cd.countdown) != expectedCountdownLen {
+					t.Fatal("coundown is incorrect", len(cd.countdown), expectedCountdownLen)
+				}
+				for j := 0; j < i; j++ {
+					err = cd.addCount()
+					if err != nil {
+						t.Fatal(err)
+					}
+					expectedCountdownLen++
+				}
+				err = cd.Close()
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+
+		// Test the durability of the WAL. We'll initialize to simulate a disk
+		// failure after the WAL commits, but before we are able to apply the
+		// commit.
+		if r & (1 << 2) == 0 {
+			for i := 0; i < 25; i++ {
+				cd, err := newCountdown(dir)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(cd.countdown) != expectedCountdownLen {
+					t.Fatal("coundown is incorrect", len(cd.countdown), expectedCountdownLen)
+				}
+
+				// Add some legitimate counts.
+				for j := 0; j < i; j++ {
+					err = cd.addCount()
+					if err != nil {
+						t.Fatal(err)
+					}
+					expectedCountdownLen++
+				}
+
+				// Add a broken count. Because the break is after the WAL commits, the
+				// count should still restore correctly on the next iteration where we
+				// call 'newCountdown'.
+				err = cd.addCountBroken()
+				if err != nil {
+					t.Fatal(err)
+				}
+				expectedCountdownLen++
+				err = cd.Close()
+				if err == nil {
+					t.Fatal("Should have returned an error but didn't")
+				}
+			}
+
+			// Check at this point that the wal is less than 100 pages.
+			info, err := os.Stat(filepath.Join(dir, "wal.dat"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Size() > 100*pageSize {
+				t.Error("the wal is too large")
+			}
+		}
+
+		// Test the parallelism. Basic way to do that is to have a second file that
+		// we update in parallel transactions. But I'd also like to be able to test
+		// parallel transactions that act on the same file? Not sure if that's
+		// strictly necessary. But we could have a second file that perhaps tracks
+		// two unrelated fields, like 5 integer arrays that are all intialized with
+		// the same integers, over 10kb or something. And then that file could have
+		// 3 independent sets of these things, so they all have clear dependence
+		// within but no dependence next to. Then we'll update all of them and the
+		// count as well in parallel transactions.
+		if r & (1 << 3) == 0 {
+			cd, err := newCountdown(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var wg sync.WaitGroup
+			for i := uint64(0); i < 50; i++ {
+				wg.Add(1)
+				go func(i uint64) {
+					defer wg.Done()
+					for j := uint64(1); j < 200; j++ {
+						err := cd.changeSplotch(i, j)
+						if err != nil {
+							t.Error(err)
+						}
+					}
+				}(i)
+			}
+			wg.Wait()
+			err = cd.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Open and close the cd to allow the consistency checks to run.
 		cd, err := newCountdown(dir)
 		if err != nil {
 			t.Fatal(err)
 		}
-		var wg sync.WaitGroup
-		for i := uint64(0); i < 50; i++ {
-			wg.Add(1)
-			go func(i uint64) {
-				defer wg.Done()
-				for j := uint64(1); j < 200; j++ {
-					err := cd.changeSplotch(i, j)
-					if err != nil {
-						t.Error(err)
-					}
-				}
-			}(i)
-		}
-		wg.Wait()
 		err = cd.Close()
 		if err != nil {
 			t.Fatal(err)
 		}
-	}
-
-	// Open and close the cd to allow the consistency checks to run.
-	cd, err := newCountdown(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = cd.Close()
-	if err != nil {
-		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
I did some brief cleanup in the newWal function.

I compacted the metadata reading and writing substantially.

I fixed up the integration test I wrote so that instead of running permutations of the test randomly, it just runs all permutations. Because I needed to add a loop and shift all the code, it resulted in a nasty diff, but functionally only about 16 lines in the test changed. (switching from random selection to always selecting over all permutations)