### PR TITLE
add testing that introduces a dependency with a randomly failing disk

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -87,11 +87,11 @@ func (f *faultyFile) Read(p []byte) (int, error) {
 }
 func (f *faultyFile) Write(p []byte) (int, error) {
 	fail := fastrand.Intn(f.failDenominator) == 0
-	if fail {
+	f.failDenominator++
+	if fail || f.failDenominator >= 5000 {
 		f.failed = true
 		return len(p), nil
 	}
-	f.failDenominator++
 	return f.file.Write(p)
 }
 func (f *faultyFile) Close() error { return f.file.Close() }
@@ -103,11 +103,11 @@ func (f *faultyFile) ReadAt(p []byte, off int64) (int, error) {
 }
 func (f *faultyFile) WriteAt(p []byte, off int64) (int, error) {
 	fail := fastrand.Intn(f.failDenominator) == 0
-	if fail {
+	f.failDenominator++
+	if fail || f.failDenominator >= 5000 {
 		f.failed = true
 		return len(p), nil
 	}
-	f.failDenominator++
 	return f.file.WriteAt(p, off)
 }
 func (f *faultyFile) Stat() (os.FileInfo, error) {
@@ -134,12 +134,12 @@ func (faultyDiskDependency) openFile(path string, flag int, perm os.FileMode) (f
 	if err != nil {
 		return nil, err
 	}
-	return &faultyFile{f, false, 2}, nil
+	return &faultyFile{f, false, 3}, nil
 }
 func (faultyDiskDependency) create(path string) (file, error) {
 	f, err := os.Create(path)
 	if err != nil {
 		return nil, err
 	}
-	return &faultyFile{f, false, 2}, nil
+	return &faultyFile{f, false, 3}, nil
 }

--- a/dependencies.go
+++ b/dependencies.go
@@ -124,7 +124,7 @@ func (f *faultyFile) Sync() error {
 type faultyDiskDependency struct{}
 
 func (faultyDiskDependency) disrupt(s string) bool {
-	return false
+	return s == "FaultyDisk"
 }
 func (faultyDiskDependency) readFile(path string) ([]byte, error) {
 	return ioutil.ReadFile(path)

--- a/dependencies.go
+++ b/dependencies.go
@@ -76,7 +76,7 @@ type faultyFile struct {
 	file   *os.File
 	failed bool
 
-	// failDenominator determins how likely it is that a write will fail, defined
+	// failDenominator determines how likely it is that a write will fail, defined
 	// as 1/failDenominator. Each write call increments failDenominator, and it
 	// starts at 2. This means that the more calls to WriteAt, the less likely
 	// the write is to fail. All calls will start automatically failing after

--- a/dependencies.go
+++ b/dependencies.go
@@ -60,25 +60,14 @@ func (dependencyReleaseFail) disrupt(s string) bool {
 type prodDependencies struct{}
 
 func (prodDependencies) disrupt(string) bool { return false }
-
 func (prodDependencies) readFile(path string) ([]byte, error) {
 	return ioutil.ReadFile(path)
 }
-
 func (prodDependencies) openFile(path string, flag int, perm os.FileMode) (file, error) {
 	return os.OpenFile(path, flag, perm)
 }
-
 func (prodDependencies) create(path string) (file, error) {
 	return os.Create(path)
-}
-
-type prodFile struct {
-	*os.File
-}
-
-func (f *prodFile) Seek(offset int64, whence int) (int64, error) {
-	return f.Seek(offset, whence)
 }
 
 // faultyFile implements a file that simulates a faulty disk.

--- a/dependencies.go
+++ b/dependencies.go
@@ -78,7 +78,8 @@ type faultyFile struct {
 	// failDenominator determins how likely it is that a write will fail, defined
 	// as 1/failDenominator. Each write call increments failDenominator, and it
 	// starts at 2. This means that the more calls to WriteAt, the less likely
-	// the write is to fail.
+	// the write is to fail. All calls will start automatically failing after
+	// 5000 writes.
 	failDenominator int
 }
 

--- a/sync.go
+++ b/sync.go
@@ -26,7 +26,7 @@ func (w *WAL) threadedSync() {
 
 		// If the sync fails we should abort to avoid more corruption
 		if err := w.logFile.Sync(); err != nil {
-			panic(build.ExtendErr("Failed to sync wal. Aborting to avoid corruption", err))
+			build.Critical(build.ExtendErr("Failed to sync wal. Aborting to avoid corruption", err))
 		}
 
 		// Signal waiting threads that they can continue execution

--- a/sync.go
+++ b/sync.go
@@ -26,7 +26,9 @@ func (w *WAL) threadedSync() {
 
 		// If the sync fails we should abort to avoid more corruption
 		if err := w.logFile.Sync(); err != nil {
-			build.Critical(build.ExtendErr("Failed to sync wal. Aborting to avoid corruption", err))
+			if !w.deps.disrupt("FaultyDisk") {
+				build.Critical(build.ExtendErr("Failed to sync wal. Aborting to avoid corruption", err))
+			}
 		}
 
 		// Signal waiting threads that they can continue execution

--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -411,6 +411,10 @@ func unmarshalPage(p *page, b []byte) (nextPage uint64, err error) {
 	// Read payloadSize
 	var payloadSize uint64
 	err5 := binary.Read(buffer, binary.LittleEndian, &payloadSize)
+	if payloadSize == 0 || payloadSize > maxPayloadSize {
+		err = errors.New("invalid page size")
+		return
+	}
 
 	// Read payload
 	p.payload = make([]byte, payloadSize)

--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -412,7 +412,7 @@ func unmarshalPage(p *page, b []byte) (nextPage uint64, err error) {
 	var payloadSize uint64
 	err5 := binary.Read(buffer, binary.LittleEndian, &payloadSize)
 	if payloadSize == 0 || payloadSize > maxPayloadSize {
-		err = errors.New("invalid page size")
+		err = errors.New("invalid page payload size")
 		return
 	}
 

--- a/writeaheadlog_test.go
+++ b/writeaheadlog_test.go
@@ -165,10 +165,6 @@ func TestWALInconsistentSync(t *testing.T) {
 	}
 	defer wt.Close()
 
-	// this test generates a lot of build.Criticals. Suppress stderr so it
-	// doesn't create a lot of useless test output.
-	os.Stderr = nil
-
 	// for 20 seconds, create large transactions and commit them to the wal, then
 	// reopen the WAL. The WAL should stay consistent.
 	for start := time.Now(); time.Since(start) < time.Second*10; time.Sleep(time.Millisecond * 100) {

--- a/writeaheadlog_test.go
+++ b/writeaheadlog_test.go
@@ -152,6 +152,8 @@ func TestCommitFailed(t *testing.T) {
 // error on sync.
 func TestWALInconsistentSync(t *testing.T) {
 	var wt *walTester
+	// initialize a new wal using the faulty disk dependency. Retry since the
+	// faulty disk can cause initialization to fail
 	err := build.Retry(50, time.Millisecond*100, func() error {
 		tester, err := newWALTester(t.Name(), faultyDiskDependency{})
 		if err != nil {

--- a/writeaheadlog_test.go
+++ b/writeaheadlog_test.go
@@ -167,7 +167,7 @@ func TestWALInconsistentSync(t *testing.T) {
 
 	// for 20 seconds, create large transactions and commit them to the wal, then
 	// reopen the WAL. The WAL should stay consistent.
-	for start := time.Now(); time.Since(start) < time.Second*10; time.Sleep(time.Millisecond * 100) {
+	for start := time.Now(); time.Since(start) < time.Second*20; time.Sleep(time.Millisecond * 100) {
 		err := func() error {
 			updates := []Update{}
 			for i := 0; i < 99; i++ {


### PR DESCRIPTION
This PR adds `TestWALInconsistentSync` as well as a new `faultyDiskDependency` which simulates and tests the WAL on a disk that randomly fails writes and syncs.

This also found and fixes a bug that would cause an infinite hang and exhaust all memory if `p.payloadSize == 0`, and adds a check for `p.payloadSize > maxPayloadSize` in `unmarshalPage`.