### PR TITLE
Add append call to transaction

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -426,8 +426,7 @@ func (w *WAL) NewTransaction(updates []Update) (*Transaction, error) {
 	return &newTransaction, nil
 }
 
-// writeToFile writes all the pages of the transaction to disk starting at a
-// specified index
+// writeToFile writes all the pages of the transaction to disk
 func (t *Transaction) writeToFile() error {
 	buf := make([]byte, pageSize)
 	for page := t.firstPage; page != nil; page = page.nextPage {

--- a/transaction.go
+++ b/transaction.go
@@ -349,10 +349,7 @@ func (t *Transaction) append(updates []Update, done chan error) {
 			return
 		}
 	}
-	if err := t.wal.logFile.Sync(); err != nil {
-		done <- build.ExtendErr("Syncing the WAL to disk failed", err)
-		return
-	}
+	t.wal.fSync()
 
 	// Link the new pages to the last one and sync the last page
 	b := lastPage.appendTo(buf[:0])
@@ -360,10 +357,7 @@ func (t *Transaction) append(updates []Update, done chan error) {
 		done <- build.ExtendErr("Writing the last page to disk failed", err)
 		return
 	}
-	if err := t.wal.logFile.Sync(); err != nil {
-		done <- build.ExtendErr("Syncing the last page to disk failed", err)
-		return
-	}
+	t.wal.fSync()
 
 	// Append the updates to the transaction
 	t.Updates = append(t.Updates, updates...)

--- a/transaction.go
+++ b/transaction.go
@@ -308,9 +308,6 @@ func (t *Transaction) append(updates []Update, done chan error) {
 		return
 	}
 
-	// Append the updates to the transaction
-	t.Updates = append(t.Updates, updates...)
-
 	// Marshal the data
 	data, err := marshalUpdates(updates)
 	if err != nil {
@@ -367,6 +364,9 @@ func (t *Transaction) append(updates []Update, done chan error) {
 		done <- build.ExtendErr("Syncing the last page to disk failed", err)
 		return
 	}
+
+	// Append the updates to the transaction
+	t.Updates = append(t.Updates, updates...)
 }
 
 // Append appends additional updates to a transaction

--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -154,6 +154,7 @@ func newWal(path string, deps dependencies) (u []Update, w *WAL, err error) {
 
 	// When we create a new wal we don't need the caller to signal recoveryComplete
 	newWal.recoveryComplete = true
+
 	return nil, &newWal, nil
 }
 
@@ -342,7 +343,8 @@ func (w *WAL) RecoveryComplete() error {
 }
 
 // managedReservePages reserves pages for a given payload. If it needs to
-// allocate new pages it will do so
+// allocate new pages it will do so. The pageStatus of the first page needs to
+// be set manually.
 func (w *WAL) managedReservePages(data []byte) []page {
 	// Find out how many pages are needed for the payload
 	numPages := len(data) / maxPayloadSize
@@ -378,12 +380,8 @@ func (w *WAL) managedReservePages(data []byte) []page {
 			pages[i].nextPage = &pages[i+1]
 		}
 
-		// Set pageStatus of the first page to pageStatusWritten
-		if i == 0 {
-			pages[i].pageStatus = pageStatusWritten
-		} else {
-			pages[i].pageStatus = pageStatusOther
-		}
+		// Set pageStatus of all pages to pageStatusOther
+		pages[i].pageStatus = pageStatusOther
 
 		// Copy part of the update into the payload
 		payloadsize := maxPayloadSize

--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -154,7 +154,6 @@ func newWal(path string, deps dependencies) (u []Update, w *WAL, err error) {
 
 	// When we create a new wal we don't need the caller to signal recoveryComplete
 	newWal.recoveryComplete = true
-
 	return nil, &newWal, nil
 }
 


### PR DESCRIPTION
`Append` allows the user to append updates to a transaction before `SignalSetupComplete` has been called. 