### PR TITLE
export MaxPayloadSize

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -4,7 +4,12 @@ const (
 	checksumSize   = 16
 	pageSize       = 4096
 	pageMetaSize   = checksumSize + 4*8 // checksum + 4 uint64s
-	maxPayloadSize = pageSize - pageMetaSize
+
+	// MaxPayloadSize is the number of bytes that can fit into a single
+	// page. For best performance, the number of pages written should be
+	// minimized, so clients should try to keep the length of an Update's
+	// Instructions field slightly below a multiple of MaxPayloadSize.
+	MaxPayloadSize = pageSize - pageMetaSize
 )
 
 const (

--- a/consts.go
+++ b/consts.go
@@ -1,9 +1,9 @@
 package writeaheadlog
 
 const (
-	checksumSize   = 16
-	pageSize       = 4096
-	pageMetaSize   = checksumSize + 4*8 // checksum + 4 uint64s
+	checksumSize = 16
+	pageSize     = 4096
+	pageMetaSize = checksumSize + 4*8 // checksum + 4 uint64s
 
 	// MaxPayloadSize is the number of bytes that can fit into a single
 	// page. For best performance, the number of pages written should be

--- a/page_test.go
+++ b/page_test.go
@@ -51,7 +51,7 @@ func BenchmarkPageAppendTo(b *testing.B) {
 	p := page{
 		offset:            4096,
 		transactionNumber: 42,
-		payload:           fastrand.Bytes(maxPayloadSize), // ensure marshalled size is 4096 bytes
+		payload:           fastrand.Bytes(MaxPayloadSize), // ensure marshalled size is 4096 bytes
 		pageStatus:        pageStatusComitted,
 		nextPage: &page{
 			offset: 12345,

--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -345,8 +345,8 @@ func (w *WAL) RecoveryComplete() error {
 // allocate new pages it will do so
 func (w *WAL) managedReservePages(data []byte) []page {
 	// Find out how many pages are needed for the payload
-	numPages := len(data) / maxPayloadSize
-	if len(data)%maxPayloadSize != 0 {
+	numPages := len(data) / MaxPayloadSize
+	if len(data)%MaxPayloadSize != 0 {
 		numPages++
 	}
 
@@ -386,12 +386,12 @@ func (w *WAL) managedReservePages(data []byte) []page {
 		}
 
 		// Copy part of the update into the payload
-		payloadsize := maxPayloadSize
-		if len(data[i*maxPayloadSize:]) < payloadsize {
-			payloadsize = len(data[i*maxPayloadSize:])
+		payloadsize := MaxPayloadSize
+		if len(data[i*MaxPayloadSize:]) < payloadsize {
+			payloadsize = len(data[i*MaxPayloadSize:])
 		}
 		pages[i].payload = make([]byte, payloadsize)
-		copy(pages[i].payload, data[i*maxPayloadSize:])
+		copy(pages[i].payload, data[i*MaxPayloadSize:])
 	}
 
 	return pages


### PR DESCRIPTION
Rationale: users of `writeaheadlog` probably care about performance, so it makes sense to export any information that will allow them to maximize performance.

That said, the usefulness of `MaxPayloadSize` depends on its stability. In other words, if we increase or decrease it later, we could break high-performance code that relies on it being a specific size.