### PR TITLE
More efficient MarshalUpdates/UnmarshalUpdates

### DIFF
--- a/writeaheadlog_test.go
+++ b/writeaheadlog_test.go
@@ -222,6 +222,26 @@ func BenchmarkMarshalUpdates(b *testing.B) {
 	}
 }
 
+func BenchmarkUnmarshalUpdates(b *testing.B) {
+	updates := make([]Update, 100)
+	for i := range updates {
+		updates[i] = Update{
+			Name:         "test",
+			Version:      "1.0",
+			Instructions: fastrand.Bytes(1234),
+		}
+	}
+	data := marshalUpdates(updates)
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := unmarshalUpdates(data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
 // TestReleaseFailed checks if a corruption of the first page of the
 // transaction during the commit is handled correctly
 func TestReleaseFailed(t *testing.T) {

--- a/writeaheadlog_test.go
+++ b/writeaheadlog_test.go
@@ -206,6 +206,22 @@ func TestWALInconsistentSync(t *testing.T) {
 	}
 }
 
+func BenchmarkMarshalUpdates(b *testing.B) {
+	updates := make([]Update, 100)
+	for i := range updates {
+		updates[i] = Update{
+			Name:         "test",
+			Version:      "1.0",
+			Instructions: fastrand.Bytes(1234),
+		}
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		marshalUpdates(updates)
+	}
+}
+
 // TestReleaseFailed checks if a corruption of the first page of the
 // transaction during the commit is handled correctly
 func TestReleaseFailed(t *testing.T) {


### PR DESCRIPTION
Benchmarks (old->new):

```
BenchmarkMarshalUpdates-4	   20000     71057 ns/op  335280 B/op     608 allocs/op
BenchmarkMarshalUpdates-4	   50000     22744 ns/op  131072 B/op       1 allocs/op

BenchmarkUnmarshalUpdates-4	   30000     45775 ns/op  151152 B/op    1111 allocs/op
BenchmarkUnmarshalUpdates-4	  200000      9165 ns/op   16736 B/op     209 allocs/op
```