### PR TITLE
don't allocate again in managedReservePages

### DIFF
--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -328,6 +328,7 @@ func (w *WAL) managedReservePages(data []byte) []page {
 	w.availablePages = w.availablePages[:len(w.availablePages)-numPages]
 
 	// Set the fields of each page
+	buf := bytes.NewBuffer(data)
 	pages := make([]page, numPages)
 	for i := range pages {
 		// Set offset according to the index in reservedPages
@@ -343,12 +344,7 @@ func (w *WAL) managedReservePages(data []byte) []page {
 		pages[i].pageStatus = pageStatusOther
 
 		// Copy part of the update into the payload
-		payloadsize := MaxPayloadSize
-		if len(data[i*MaxPayloadSize:]) < payloadsize {
-			payloadsize = len(data[i*MaxPayloadSize:])
-		}
-		pages[i].payload = make([]byte, payloadsize)
-		copy(pages[i].payload, data[i*MaxPayloadSize:])
+		pages[i].payload = buf.Next(MaxPayloadSize)
 	}
 
 	return pages


### PR DESCRIPTION
Turns out that we don't need to allocate + copy here. The data is allocated by `marshalUpdates`, and that byte slice doesn't leak out anywhere else, so it's safe to just reslice it into the pages instead of copying it.

Combining this PR with #34 results in `TestWALIntegration` allocating about 1/3rd as much memory as before (1.2GB -> 400MB).