### PR TITLE
close WAL if recovery fails

### DIFF
--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -133,6 +133,9 @@ func newWal(path string, deps dependencies) (u []Update, w *WAL, err error) {
 
 		// Recover WAL and return updates
 		updates, err := newWal.recoverWal(data)
+		if err != nil {
+			newWal.logFile.Close()
+		}
 		return updates, newWal, err
 
 	} else if !os.IsNotExist(err) {

--- a/writeaheadlog_test.go
+++ b/writeaheadlog_test.go
@@ -76,6 +76,7 @@ func newWALTester(name string, deps dependencies) (*walTester, error) {
 	}
 
 	if err := wal.RecoveryComplete(); err != nil {
+		wal.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
Not certain, but I believe this is why appveyor builds are failing: `TestWALInconsistentSync` initializes the WAL with `faultyDiskDependency`, which means startup can fail, so it retries multiple times. But on Windows, if you don't close the file handle, all subsequent `Open`s will fail too.