### PR TITLE
Refactor corrupted file dependency to allow for multiple corrupted files on the same disk

### DIFF
--- a/dependencies.go
+++ b/dependencies.go
@@ -73,11 +73,11 @@ func (prodDependencies) create(path string) (file, error) {
 
 // faultyDiskDependency implements dependencies that simulate a faulty disk.
 type faultyDiskDependency struct {
-	// failDenominator determines how likely it is that a write will fail, defined
-	// as 1/failDenominator. Each write call increments failDenominator, and it
-	// starts at 2. This means that the more calls to WriteAt, the less likely
-	// the write is to fail. All calls will start automatically failing after
-	// 5000 writes.
+	// failDenominator determines how likely it is that a write will fail,
+	// defined as 1/failDenominator. Each write call increments
+	// failDenominator, and it starts at 2. This means that the more calls to
+	// WriteAt, the less likely the write is to fail. All calls will start
+	// automatically failing after writeLimit writes.
 	failDenominator int
 	writeLimit      int
 	failed          bool

--- a/dependencies.go
+++ b/dependencies.go
@@ -71,32 +71,66 @@ func (prodDependencies) create(path string) (file, error) {
 	return os.Create(path)
 }
 
-// faultyFile implements a file that simulates a faulty disk.
-type faultyFile struct {
-	file   *os.File
-	failed bool
-
+// faultyDiskDependency implements dependencies that simulate a faulty disk.
+type faultyDiskDependency struct {
 	// failDenominator determines how likely it is that a write will fail, defined
 	// as 1/failDenominator. Each write call increments failDenominator, and it
 	// starts at 2. This means that the more calls to WriteAt, the less likely
 	// the write is to fail. All calls will start automatically failing after
 	// 5000 writes.
 	failDenominator int
+	failed          bool
+	mu              *sync.Mutex
+}
 
-	mu sync.Mutex
+// newFaultyDiskDependency creates a dependency that can be used to simulate a
+// failing disk
+func newFaultyDiskDependency() faultyDiskDependency {
+	return faultyDiskDependency{
+		failDenominator: 3,
+		failed:          false,
+		mu:              new(sync.Mutex),
+	}
+}
+
+func (faultyDiskDependency) disrupt(s string) bool {
+	return s == "FaultyDisk"
+}
+func (faultyDiskDependency) readFile(path string) ([]byte, error) {
+	return ioutil.ReadFile(path)
+}
+func (d faultyDiskDependency) openFile(path string, flag int, perm os.FileMode) (file, error) {
+	f, err := os.OpenFile(path, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+	return d.newFaultyFile(f), nil
+}
+func (d faultyDiskDependency) create(path string) (file, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, err
+	}
+	return d.newFaultyFile(f), nil
+}
+
+// faultyFile implements a file that simulates a faulty disk.
+type faultyFile struct {
+	d    *faultyDiskDependency
+	file *os.File
 }
 
 func (f *faultyFile) Read(p []byte) (int, error) {
 	return f.file.Read(p)
 }
 func (f *faultyFile) Write(p []byte) (int, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
+	f.d.mu.Lock()
+	defer f.d.mu.Unlock()
 
-	fail := fastrand.Intn(f.failDenominator) == 0
-	f.failDenominator++
-	if fail || f.failDenominator >= 5000 {
-		f.failed = true
+	fail := fastrand.Intn(f.d.failDenominator) == 0
+	f.d.failDenominator++
+	if fail || f.d.failDenominator >= 5000 {
+		f.d.failed = true
 		return len(p), nil
 	}
 	return f.file.Write(p)
@@ -109,13 +143,13 @@ func (f *faultyFile) ReadAt(p []byte, off int64) (int, error) {
 	return f.file.ReadAt(p, off)
 }
 func (f *faultyFile) WriteAt(p []byte, off int64) (int, error) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
+	f.d.mu.Lock()
+	defer f.d.mu.Unlock()
 
-	fail := fastrand.Intn(f.failDenominator) == 0
-	f.failDenominator++
-	if fail || f.failDenominator >= 5000 {
-		f.failed = true
+	fail := fastrand.Intn(f.d.failDenominator) == 0
+	f.d.failDenominator++
+	if fail || f.d.failDenominator >= 5000 {
+		f.d.failed = true
 		return len(p), nil
 	}
 	return f.file.WriteAt(p, off)
@@ -124,40 +158,16 @@ func (f *faultyFile) Stat() (os.FileInfo, error) {
 	return f.file.Stat()
 }
 func (f *faultyFile) Sync() error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
+	f.d.mu.Lock()
+	defer f.d.mu.Unlock()
 
-	if f.failed {
+	if f.d.failed {
 		return errors.New("could not write to disk (faultyDisk)")
 	}
 	return f.file.Sync()
 }
 
 // newFaultyFile creates a new faulty file around the provided file handle.
-func newFaultyFile(f *os.File) *faultyFile {
-	return &faultyFile{file: f, failed: false, failDenominator: 3}
-}
-
-// faultyDiskDependency implements dependencies that simulate a faulty disk.
-type faultyDiskDependency struct{}
-
-func (faultyDiskDependency) disrupt(s string) bool {
-	return s == "FaultyDisk"
-}
-func (faultyDiskDependency) readFile(path string) ([]byte, error) {
-	return ioutil.ReadFile(path)
-}
-func (faultyDiskDependency) openFile(path string, flag int, perm os.FileMode) (file, error) {
-	f, err := os.OpenFile(path, flag, perm)
-	if err != nil {
-		return nil, err
-	}
-	return newFaultyFile(f), nil
-}
-func (faultyDiskDependency) create(path string) (file, error) {
-	f, err := os.Create(path)
-	if err != nil {
-		return nil, err
-	}
-	return newFaultyFile(f), nil
+func (d *faultyDiskDependency) newFaultyFile(f *os.File) *faultyFile {
+	return &faultyFile{d: d, file: f}
 }

--- a/writeaheadlog_test.go
+++ b/writeaheadlog_test.go
@@ -155,7 +155,7 @@ func TestWALInconsistentSync(t *testing.T) {
 	// initialize a new wal using the faulty disk dependency. Retry since the
 	// faulty disk can cause initialization to fail
 	err := build.Retry(50, time.Millisecond*100, func() error {
-		tester, err := newWALTester(t.Name(), faultyDiskDependency{})
+		tester, err := newWALTester(t.Name(), newFaultyDiskDependency())
 		if err != nil {
 			return err
 		}

--- a/writeaheadlog_test.go
+++ b/writeaheadlog_test.go
@@ -155,7 +155,7 @@ func TestWALInconsistentSync(t *testing.T) {
 	// initialize a new wal using the faulty disk dependency. Retry since the
 	// faulty disk can cause initialization to fail
 	err := build.Retry(50, time.Millisecond*100, func() error {
-		tester, err := newWALTester(t.Name(), newFaultyDiskDependency())
+		tester, err := newWALTester(t.Name(), newFaultyDiskDependency(5000))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This PR refactors the corrupted file dependency so that we can have multiple files on the same failing disk.