### PR TITLE
Return an error from fSync instead of panicking

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -13,7 +13,6 @@ func (w *WAL) threadedSync() {
 		w.syncCond.L.Lock()
 		if w.syncCount == 0 {
 			// nothing to sync
-			w.syncing = false
 			w.syncCond.L.Unlock()
 			return
 		}
@@ -42,9 +41,11 @@ func (w *WAL) fSync() {
 	w.syncCond.L.Lock()
 	defer w.syncCond.L.Unlock()
 
-	// If there is currently no instance of the syncing thread create one
-	if !w.syncing {
-		w.syncing = true
+	// Increment the number of syncing threads
+	w.syncCount++
+
+	// If we are the only syncing thread, spawn the threadedSync loop
+	if w.syncCount == 1 {
 		go w.threadedSync()
 	}
 

--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -55,6 +55,9 @@ type WAL struct {
 	// stopChan is a channel that is used to signal a shutdown
 	stopChan chan struct{}
 
+	// syncErr is the error returned by the most recent fsync call
+	syncErr error
+
 	// recoveryComplete indicates if the caller signalled that the recovery is complete
 	recoveryComplete bool
 

--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -55,9 +55,6 @@ type WAL struct {
 	// stopChan is a channel that is used to signal a shutdown
 	stopChan chan struct{}
 
-	// syncing indicates if the syncing thread is currently being executed
-	syncing bool
-
 	// recoveryComplete indicates if the caller signalled that the recovery is complete
 	recoveryComplete bool
 


### PR DESCRIPTION
@DavidVorick should weigh in on this. My view is that it's silly to panic if `Sync` returns an error but not if `Write` returns an error. Either both should panic, or both should return an error. And my preference is to return an error, letting the caller decide how the want to proceed.
I think we all agree that a failed `Write` (or `Sync`) is a critical error and in most cases, the user of the WAL should terminate their program ASAP to prevent further corruption. Panicking forces the program to exit unless the caller explicitly wraps the call in a `recover`. I think this is too heavy-handed. We should leave it up to the user how they want to handle the error.

Another possibility to consider is locking the WAL into an unusable state if a `Write` or `Sync` call fails. This PR adds a `syncErr` field, so all we have to do is make all of the WAL's exported functions (except for `Close`) check for `syncErr != nil` and return a sentinel error if so. This would prevent any further corruption to the WAL without having to panic.