### PR TITLE
fix bug in silo test

### DIFF
--- a/writeaheadlog_integration_test.go
+++ b/writeaheadlog_integration_test.go
@@ -242,7 +242,7 @@ func (s *silo) threadedUpdate(t *testing.T, w *WAL, dataPath string, wg *sync.Wa
 		}
 
 		// Append the remaining updates
-		if err := txn.Append(updates[appendFrom:]); err != nil {
+		if err := <-txn.Append(updates[appendFrom:]); err != nil {
 			return
 		}
 
@@ -384,7 +384,7 @@ func TestSilo(t *testing.T) {
 	numSilos := int64(250)
 	numIncrease := 20
 	maxCntr := 50
-	numRetries := 1000
+	numRetries := 100
 	counters := make([]int, maxCntr, maxCntr)
 	endTime := time.Now().Add(5 * time.Minute)
 	iters := 0


### PR DESCRIPTION
Checking the channel instead of the error it returned caused the threads to abort immediately, even without an actual error occuring. This PR fixes that but causes the test to fail. Probably due to this [issue](https://github.com/NebulousLabs/writeaheadlog/issues/45).