### PR TITLE
add boolean to speed up performance

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -9,6 +9,7 @@ func (w *WAL) threadedSync() {
 		w.syncCond.L.Lock()
 		if w.syncCount == 0 {
 			// nothing to sync
+			w.syncing = false
 			w.syncCond.L.Unlock()
 			return
 		}
@@ -40,7 +41,8 @@ func (w *WAL) fSync() error {
 	w.syncCount++
 
 	// If we are the only syncing thread, spawn the threadedSync loop
-	if w.syncCount == 1 {
+	if !w.syncing {
+		w.syncing = true
 		go w.threadedSync()
 	}
 

--- a/writeaheadlog.go
+++ b/writeaheadlog.go
@@ -58,6 +58,9 @@ type WAL struct {
 	// stopChan is a channel that is used to signal a shutdown
 	stopChan chan struct{}
 
+	// syncing indicates if the syncing thread is currently being executed
+	syncing bool
+
 	// syncErr is the error returned by the most recent fsync call
 	syncErr error
 


### PR DESCRIPTION
I'm not sure why this makes this much of a difference but this PR improves the performance of the `BenchmarkTransactionSpeed10` benchmark from around `600 txn/s` to `1200 txn/s`.