### PR TITLE
add timeout at the end of sync thread

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -1,5 +1,9 @@
 package writeaheadlog
 
+import (
+	"time"
+)
+
 // threadedSync syncs the WAL in regular intervals
 func (w *WAL) threadedSync() {
 	for {
@@ -28,6 +32,9 @@ func (w *WAL) threadedSync() {
 
 		// Signal waiting threads that they can continue execution
 		w.syncCond.Broadcast()
+
+		// Wait a millisecond to allow for more syncs to queue up
+		<-time.After(time.Nanosecond)
 	}
 }
 

--- a/sync.go
+++ b/sync.go
@@ -34,7 +34,7 @@ func (w *WAL) threadedSync() {
 		w.syncCond.Broadcast()
 
 		// Wait a millisecond to allow for more syncs to queue up
-		<-time.After(time.Nanosecond)
+		time.Sleep(time.Nanosecond)
 	}
 }
 

--- a/writeaheadlog_test.go
+++ b/writeaheadlog_test.go
@@ -942,7 +942,7 @@ func benchmarkTransactionSpeed(b *testing.B, numThreads int, appendUpdate bool) 
 // BenchmarkTransactionSpeedAppend runs benchmarkTransactionSpeed with append =
 // false
 func BenchmarkTransactionSpeed(b *testing.B) {
-	numThreads := []int{1, 10, 100, 1000}
+	numThreads := []int{1, 10, 50, 100}
 	for _, n := range numThreads {
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			benchmarkTransactionSpeed(b, n, false)
@@ -953,7 +953,7 @@ func BenchmarkTransactionSpeed(b *testing.B) {
 // BenchmarkTransactionSpeedAppend runs benchmarkTransactionSpeed with append =
 // true
 func BenchmarkTransactionSpeedAppend(b *testing.B) {
-	numThreads := []int{1, 10, 100, 1000}
+	numThreads := []int{1, 10, 50, 100}
 	for _, n := range numThreads {
 		b.Run(strconv.Itoa(n), func(b *testing.B) {
 			benchmarkTransactionSpeed(b, n, true)


### PR DESCRIPTION
I did some research regarding [#62](https://github.com/NebulousLabs/writeaheadlog/issues/62) and it seems that syncs are not batched up efficiently on Windows for some reason. This PR introduces a very small sleep at the end of the sync loop to allow other goroutines to queue syncs. I tested this with a simple `runtime.Gosched()` but it seems that waiting for 1 nanosecond performs better.

This change has a minor impact on the performance on my Linux machine (~2-3%), but increases the performance on Windows drastically.