### PR TITLE
Allow the caller to ignore uncommitted transactions on shutdown and startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ if len(updates) != 0 {
 	applyUpdates(recoveredTxns)
 
 	// After the recovery is complete we can signal the WAL that we are
-	// done that the updates were applied.
+	// done and that the updates were applied.
+	// NOTE: This is optional. If for some reason an update cannot be
+	// applied right away it may be skipped and applied later
 	for _, txn := range recoveredTxns {
 		if err := txn.SignalUpdatesApplied; err != nil {
 			return err

--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@ to the caller to guarantee that the instructions are idempotent and consistent.
 
 First the wal needs to be opened by calling `New(string path)`. This will
 create a new WAL at the provided path or load an existing one. The latter will
-recover the WAL and return all the updates of transactions that were not
-completed.
+recover the WAL and return all the transactions that were not completed.
 
 ```
 // Open the WAL.
-updates, wal, err := New(walPath)
+recoveredTxns, wal, err := New(walPath)
 if err != nil {
 	return err
 }
@@ -24,13 +23,14 @@ if err != nil {
 if len(updates) != 0 {
 	// Apparently the system crashed. Handle the unfinished updates
 	// accordingly.
-	applyUpdates(updates)
+	applyUpdates(recoveredTxns)
 
-	// After the recovery is complete we need to signal the WAL that we are
-	// done. All calls to 'NewTransaction' will return an error until
-	// RecoveryComplete() has been called.
-	if err := wal.RecoveryComplete(); err != nil {
-		return err
+	// After the recovery is complete we can signal the WAL that we are
+	// done that the updates were applied.
+	for _, txn := range recoveredTxns {
+		if err := txn.SignalUpdatesApplied; err != nil {
+			return err
+		}
 	}
 }
 ```

--- a/consts.go
+++ b/consts.go
@@ -45,7 +45,6 @@ const (
 	recoveryStateInvalid = iota
 	recoveryStateClean
 	recoveryStateUnclean
-	recoveryStateWipe
 )
 
 var (

--- a/sync.go
+++ b/sync.go
@@ -19,6 +19,7 @@ type syncState struct {
 // threadedSync syncs the WAL in regular intervals, exiting if there is no more
 // work to do.
 func (w *WAL) threadedSync() {
+	defer w.wg.Done()
 	for {
 		// Check if there is a syncing job. If there is no syncing job, the
 		// thread can return.
@@ -63,6 +64,7 @@ func (w *WAL) fSync() error {
 	// If the status was previously '0', there is no syncing thread, and a new
 	// one must be spawned.
 	if oldStatus == 0 {
+		w.wg.Add(1)
 		go w.threadedSync()
 	}
 

--- a/transaction.go
+++ b/transaction.go
@@ -499,9 +499,6 @@ func (t *Transaction) writePage(page *page) error {
 
 // NewTransaction creates a transaction from a set of updates.
 func (w *WAL) NewTransaction(updates []Update) (*Transaction, error) {
-	if !w.recoveryComplete {
-		return nil, errors.New("can't call NewTransaction before recovery is complete")
-	}
 	// Check that there are updates for the transaction to process.
 	if len(updates) == 0 {
 		return nil, errors.New("cannot create a transaction without updates")

--- a/writeaheadlog_integration_test.go
+++ b/writeaheadlog_integration_test.go
@@ -535,6 +535,7 @@ func TestSilo(t *testing.T) {
 	maxRetries := 0
 	totalRetries := 0
 	numSkipped := 0
+	totalSkipped := 0
 	for i = 0; i < maxIters; i++ {
 		if time.Now().After(endTime) {
 			// Stop if test takes too long
@@ -607,6 +608,9 @@ func TestSilo(t *testing.T) {
 		if retries > maxRetries {
 			maxRetries = retries - 1
 		}
+
+		// Statistics about how many transactions are skipped.
+		totalSkipped += numSkipped
 	}
 
 	// Fetch the size of the wal file for the stats reporting.
@@ -623,5 +627,6 @@ func TestSilo(t *testing.T) {
 	t.Logf("Number of iterations: %v", i)
 	t.Logf("Max number of retries: %v", maxRetries)
 	t.Logf("Average number of retries: %v", totalRetries/i)
+	t.Logf("Average number of skipped txns: %v", totalSkipped/i)
 	t.Logf("WAL size: %v bytes", fi.Size())
 }

--- a/writeaheadlog_integration_test.go
+++ b/writeaheadlog_integration_test.go
@@ -173,6 +173,9 @@ func (su siloUpdate) applyUpdate(silo *silo, dataPath string) error {
 			return err
 		}
 	}
+
+	// Update the silos cs field
+	silo.cs = su.newChecksum
 	return nil
 }
 
@@ -301,7 +304,6 @@ func (s *silo) threadedUpdate(t *testing.T, w *WAL, dataPath string, wg *sync.Wa
 		// Reset random data and checksum if we used it
 		if newFile {
 			randomData = fastrand.Bytes(10 * pageSize)
-			s.cs = ncs
 			ncs = computeChecksum(randomData)
 		}
 


### PR DESCRIPTION
There might be a chance that the caller cannot apply an update right away. If that is the case he should be still be able to close the wal and to recover and use it without applying those transactions.