### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ if err != nil {
 	return err
 }
 
-if len(updates) != 0 {
+if len(recoveredTxns) != 0 {
 	// Apparently the system crashed. Handle the unfinished updates
 	// accordingly.
 	applyUpdates(recoveredTxns)


### PR DESCRIPTION
I haven't tried to compile this, but I think the example in the readme should be checking if there is >1 recoveredTransactions (instead of updates which doesn't appear to be defined)